### PR TITLE
Remove try catch within item searcher and item updater classes 

### DIFF
--- a/src/main/java/ExternalInterface/ItemSearcher.java
+++ b/src/main/java/ExternalInterface/ItemSearcher.java
@@ -135,29 +135,25 @@ public class ItemSearcher {
         String url = this.itemLinkGenerator(keywords);
         ArrayList<Product> itemList = new ArrayList<>();
         ArrayList<String> listUrls = new ArrayList<>();
-
-        try {
-            Document doc = Jsoup.connect(url).timeout(10000).userAgent("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36").get();
-            Elements productUrls = doc.select("h2.a-size-mini.a-spacing-none.a-color-base a");
-            for (Element item : productUrls) {
-                String newUrl = "https://www.amazon.ca" + item.attr("href");
-                listUrls.add(newUrl);
-            }
-            int counter = 0;
-            for (String itemUrl : listUrls) {
-                if (counter == 10) {
-                    break;
-                }
-                Product item = searchItemUrl(itemUrl, true);
-                if (!Objects.equals(item.getProductName(), "") && item.getProductPrice() != 0) {
-                    itemList.add(item);
-                    counter += 1;
-                }
-            }
-            return itemList;
-        } catch (IOException e) {
-            return new ArrayList<>();
+        Document doc = Jsoup.connect(url).timeout(10000).userAgent("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36").get();
+        Elements productUrls = doc.select("h2.a-size-mini.a-spacing-none.a-color-base a");
+        for (Element item : productUrls) {
+            String newUrl = "https://www.amazon.ca" + item.attr("href");
+            listUrls.add(newUrl);
         }
+        int counter = 0;
+        for (String itemUrl : listUrls) {
+            if (counter == 10) {
+                break;
+            }
+            Product item = searchItemUrl(itemUrl, true);
+            if (!Objects.equals(item.getProductName(), "") && item.getProductPrice() != 0) {
+                itemList.add(item);
+                counter += 1;
+            }
+        }
+        return itemList;
+
     }
 
     /**
@@ -166,54 +162,53 @@ public class ItemSearcher {
      * @param url url of amazon item
      */
     public Product searchItemUrl(String url, boolean searchByKeyword) throws IOException {
-        try {
-            // This line specifies window type and layout of amazon page based on  Window Version and browser for webscraping
-            Document doc = Jsoup.connect(url).timeout(10000).userAgent("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36").get();
-            Element htmlName = doc.select(".a-size-large.product-title-word-break").first();
-            Element price = doc.select(".a-offscreen").first();
-            Element htmlDescription = doc.select("div.a-row.feature").select("div.a-section.a-spacing-small").select("span").first();
-            Element htmlCountRating = doc.select("div.a-row.a-spacing-medium.averageStarRatingNumerical").select("span.a-size-base.a-color-secondary").first();
-            Element htmlImgUrl = doc.select("ul.a-unordered-list.a-nostyle.a-horizontal.list.maintain-height").select("span.a-list-item span.a-declarative").select("span.a-declarative").select("div.imgTagWrapper").select("img").first();
-            Element htmlStarRating = doc.select("div.a-fixed-left-grid-col.aok-align-center.a-col-right").select("div.a-row").select("span.a-size-base.a-nowrap").first();
 
-            if ((htmlName == null || price == null || htmlDescription == null || htmlCountRating == null || htmlImgUrl == null || htmlStarRating == null) && searchByKeyword) {
-                return new Item("", 0, 0, "", "", new String[]{}, 0, 0, "");
-            }
-            double sellingPrice = 0;
-            String description = "";
-            String name = "";
-            String imgUrl = "";
-            int countRating = 0;
-            double starRating = 0;
-            assert price != null;
-            String sellingPriceStr = price.text().replace(",", "").substring(1);
+        // This line specifies window type and layout of amazon page based on  Window Version and browser for webscraping
+        Document doc = Jsoup.connect(url).timeout(10000).userAgent("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36").get();
+        Element htmlName = doc.select(".a-size-large.product-title-word-break").first();
+        Element price = doc.select(".a-offscreen").first();
+        Element htmlDescription = doc.select("div.a-row.feature").select("div.a-section.a-spacing-small").select("span").first();
+        Element htmlCountRating = doc.select("div.a-row.a-spacing-medium.averageStarRatingNumerical").select("span.a-size-base.a-color-secondary").first();
+        Element htmlImgUrl = doc.select("ul.a-unordered-list.a-nostyle.a-horizontal.list.maintain-height").select("span.a-list-item span.a-declarative").select("span.a-declarative").select("div.imgTagWrapper").select("img").first();
+        Element htmlStarRating = doc.select("div.a-fixed-left-grid-col.aok-align-center.a-col-right").select("div.a-row").select("span.a-size-base.a-nowrap").first();
 
-            if (!sellingPriceStr.matches(".*[a-zA-Z]+.*")) {
-
-                sellingPrice = Double.parseDouble(sellingPriceStr);
-
-                if (!userCurrency.equals("CAD")){
-                    sellingPrice /= currencyChange;
-                }
-            }
-            if (htmlCountRating != null) {
-                countRating = Integer.parseInt(htmlCountRating.text().replace(",", "").split(" ")[0]);
-            }
-            if (htmlStarRating != null) {
-                starRating = Double.parseDouble(htmlStarRating.text().split(" ")[0]);
-            }
-            if (htmlImgUrl != null) {
-                imgUrl = htmlImgUrl.attr("src");
-            }
-            if (htmlName != null) {
-                name = htmlName.text();
-            }
-            if (htmlDescription != null) {
-                description = htmlDescription.text();
-            }
-            return new Item(name, sellingPrice, sellingPrice, url, description, new String[]{}, countRating, starRating, imgUrl);
-        } catch (IOException e) {
-            return new Item("", 0, 0, "", "", new String[]{}, 0, 0, "", "CAD");
+        if ((htmlName == null || price == null || htmlDescription == null || htmlCountRating == null || htmlImgUrl == null || htmlStarRating == null) && searchByKeyword) {
+            return new Item("", 0, 0, "", "", new String[]{}, 0, 0, "");
         }
+        double sellingPrice = 0;
+        String description = "";
+        String name = "";
+        String imgUrl = "";
+        int countRating = 0;
+        double starRating = 0;
+        assert price != null;
+        String sellingPriceStr = price.text().replace(",", "").substring(1);
+
+        if (!sellingPriceStr.matches(".*[a-zA-Z]+.*")) {
+
+            sellingPrice = Double.parseDouble(sellingPriceStr);
+
+            if (!userCurrency.equals("CAD")){
+                sellingPrice /= currencyChange;
+            }
+        }
+        if (htmlCountRating != null) {
+            countRating = Integer.parseInt(htmlCountRating.text().replace(",", "").split(" ")[0]);
+        }
+        if (htmlStarRating != null) {
+            starRating = Double.parseDouble(htmlStarRating.text().split(" ")[0]);
+        }
+        if (htmlImgUrl != null) {
+            imgUrl = htmlImgUrl.attr("src");
+        }
+        if (htmlName != null) {
+            name = htmlName.text();
+        }
+        if (htmlDescription != null) {
+            description = htmlDescription.text();
+        }
+        return new Item(name, sellingPrice, sellingPrice, url, description, new String[]{}, countRating, starRating, imgUrl);
+
+
     }
 }

--- a/src/main/java/ExternalInterface/ItemSearcher.java
+++ b/src/main/java/ExternalInterface/ItemSearcher.java
@@ -135,24 +135,27 @@ public class ItemSearcher {
         String url = this.itemLinkGenerator(keywords);
         ArrayList<Product> itemList = new ArrayList<>();
         ArrayList<String> listUrls = new ArrayList<>();
-        Document doc = Jsoup.connect(url).timeout(10000).userAgent("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36").get();
-        Elements productUrls = doc.select("h2.a-size-mini.a-spacing-none.a-color-base a");
-        for (Element item : productUrls) {
-            String newUrl = "https://www.amazon.ca" + item.attr("href");
-            listUrls.add(newUrl);
-        }
-        int counter = 0;
-        for (String itemUrl : listUrls) {
-            if (counter == 10) {
-                break;
+
+
+            Document doc = Jsoup.connect(url).timeout(10000).userAgent("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36").get();
+            Elements productUrls = doc.select("h2.a-size-mini.a-spacing-none.a-color-base a");
+            for (Element item : productUrls) {
+                String newUrl = "https://www.amazon.ca" + item.attr("href");
+                listUrls.add(newUrl);
             }
-            Product item = searchItemUrl(itemUrl, true);
-            if (!Objects.equals(item.getProductName(), "") && item.getProductPrice() != 0) {
-                itemList.add(item);
-                counter += 1;
+            int counter = 0;
+            for (String itemUrl : listUrls) {
+                if (counter == 10) {
+                    break;
+                }
+                Product item = searchItemUrl(itemUrl, true);
+                if (!Objects.equals(item.getProductName(), "") && item.getProductPrice() != 0) {
+                    itemList.add(item);
+                    counter += 1;
+                }
             }
-        }
-        return itemList;
+            return itemList;
+
 
     }
 
@@ -163,52 +166,51 @@ public class ItemSearcher {
      */
     public Product searchItemUrl(String url, boolean searchByKeyword) throws IOException {
 
-        // This line specifies window type and layout of amazon page based on  Window Version and browser for webscraping
-        Document doc = Jsoup.connect(url).timeout(10000).userAgent("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36").get();
-        Element htmlName = doc.select(".a-size-large.product-title-word-break").first();
-        Element price = doc.select(".a-offscreen").first();
-        Element htmlDescription = doc.select("div.a-row.feature").select("div.a-section.a-spacing-small").select("span").first();
-        Element htmlCountRating = doc.select("div.a-row.a-spacing-medium.averageStarRatingNumerical").select("span.a-size-base.a-color-secondary").first();
-        Element htmlImgUrl = doc.select("ul.a-unordered-list.a-nostyle.a-horizontal.list.maintain-height").select("span.a-list-item span.a-declarative").select("span.a-declarative").select("div.imgTagWrapper").select("img").first();
-        Element htmlStarRating = doc.select("div.a-fixed-left-grid-col.aok-align-center.a-col-right").select("div.a-row").select("span.a-size-base.a-nowrap").first();
+            // This line specifies window type and layout of amazon page based on  Window Version and browser for webscraping
+            Document doc = Jsoup.connect(url).timeout(10000).userAgent("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36").get();
+            Element htmlName = doc.select(".a-size-large.product-title-word-break").first();
+            Element price = doc.select(".a-offscreen").first();
+            Element htmlDescription = doc.select("div.a-row.feature").select("div.a-section.a-spacing-small").select("span").first();
+            Element htmlCountRating = doc.select("div.a-row.a-spacing-medium.averageStarRatingNumerical").select("span.a-size-base.a-color-secondary").first();
+            Element htmlImgUrl = doc.select("ul.a-unordered-list.a-nostyle.a-horizontal.list.maintain-height").select("span.a-list-item span.a-declarative").select("span.a-declarative").select("div.imgTagWrapper").select("img").first();
+            Element htmlStarRating = doc.select("div.a-fixed-left-grid-col.aok-align-center.a-col-right").select("div.a-row").select("span.a-size-base.a-nowrap").first();
 
-        if ((htmlName == null || price == null || htmlDescription == null || htmlCountRating == null || htmlImgUrl == null || htmlStarRating == null) && searchByKeyword) {
-            return new Item("", 0, 0, "", "", new String[]{}, 0, 0, "");
-        }
-        double sellingPrice = 0;
-        String description = "";
-        String name = "";
-        String imgUrl = "";
-        int countRating = 0;
-        double starRating = 0;
-        assert price != null;
-        String sellingPriceStr = price.text().replace(",", "").substring(1);
-
-        if (!sellingPriceStr.matches(".*[a-zA-Z]+.*")) {
-
-            sellingPrice = Double.parseDouble(sellingPriceStr);
-
-            if (!userCurrency.equals("CAD")){
-                sellingPrice /= currencyChange;
+            if ((htmlName == null || price == null || htmlDescription == null || htmlCountRating == null || htmlImgUrl == null || htmlStarRating == null) && searchByKeyword) {
+                return new Item("", 0, 0, "", "", new String[]{}, 0, 0, "");
             }
-        }
-        if (htmlCountRating != null) {
-            countRating = Integer.parseInt(htmlCountRating.text().replace(",", "").split(" ")[0]);
-        }
-        if (htmlStarRating != null) {
-            starRating = Double.parseDouble(htmlStarRating.text().split(" ")[0]);
-        }
-        if (htmlImgUrl != null) {
-            imgUrl = htmlImgUrl.attr("src");
-        }
-        if (htmlName != null) {
-            name = htmlName.text();
-        }
-        if (htmlDescription != null) {
-            description = htmlDescription.text();
-        }
-        return new Item(name, sellingPrice, sellingPrice, url, description, new String[]{}, countRating, starRating, imgUrl);
+            double sellingPrice = 0;
+            String description = "";
+            String name = "";
+            String imgUrl = "";
+            int countRating = 0;
+            double starRating = 0;
+            assert price != null;
+            String sellingPriceStr = price.text().replace(",", "").substring(1);
 
+            if (!sellingPriceStr.matches(".*[a-zA-Z]+.*")) {
+
+                sellingPrice = Double.parseDouble(sellingPriceStr);
+
+                if (!userCurrency.equals("CAD")){
+                    sellingPrice /= currencyChange;
+                }
+            }
+            if (htmlCountRating != null) {
+                countRating = Integer.parseInt(htmlCountRating.text().replace(",", "").split(" ")[0]);
+            }
+            if (htmlStarRating != null) {
+                starRating = Double.parseDouble(htmlStarRating.text().split(" ")[0]);
+            }
+            if (htmlImgUrl != null) {
+                imgUrl = htmlImgUrl.attr("src");
+            }
+            if (htmlName != null) {
+                name = htmlName.text();
+            }
+            if (htmlDescription != null) {
+                description = htmlDescription.text();
+            }
+            return new Item(name, sellingPrice, sellingPrice, url, description, new String[]{}, countRating, starRating, imgUrl);
 
     }
 }


### PR DESCRIPTION
Removed try catch within item search and item updater to abide with clean arch. This ensures that all instances of try catch are located within GUI. Can confirm that without the try catch, item search and item updater still passes tests.